### PR TITLE
Feature mqtt

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,6 +1,11 @@
+# Network settings
 hostname = 'if you want your device to have a hostname. optional'
 wifi_ssid = 'the WiFi network name'
 wifi_password = 'the WiFi network password'
+
+# MQTT settings
 mqtt_host = 'where to pub/sub MQTT messages'
 mqtt_user = 'MQTT server username'
 mqtt_password = 'MQTT server password'
+mqtt_set = 'mqtt topic warp core listens to'
+mqtt_state = 'mqtt topic warp core sends updates to'

--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,6 @@
+hostname = 'if you want your device to have a hostname. optional'
+wifi_ssid = 'the WiFi network name'
+wifi_password = 'the WiFi network password'
+mqtt_host = 'where to pub/sub MQTT messages'
+mqtt_user = 'MQTT server username'
+mqtt_password = 'MQTT server password'

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
+secrets.py
 .vscode/
 venv/

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.env
 secrets.py
 .vscode/
 venv/

--- a/code.py
+++ b/code.py
@@ -3,6 +3,7 @@ import time
 import board
 import digitalio
 import neopixel
+import wifi
 
 import effects
 
@@ -48,9 +49,24 @@ def get_by_index(effect: int, speed: int) -> effects.EffectEntry:
     except:
         return effects.NOT_FOUND_EFFECT
 
+from secrets import secrets
+
+if "name" in secrets:
+    wifi.radio.hostname = secrets["name"]
+print("Connecting to %s" % secrets["wifi"])
+wifi.radio.connect(secrets["wifi"], secrets["wifi_pw"])
+print("Connected to %s with address %s" % (secrets["wifi"], wifi.radio.ipv4_address))
+# TODO: Add logic to show errors with connections.
+
+
+pixels.fill((100,100,0))
+pixels.show()
+time.sleep(1)
+pixels.fill((0,0,0))
+pixels.show()
 
 # hard coding initial
-current_entry = get_by_name("cometbounce_purple_0.1")
+current_entry = get_by_name("nothing_")
 current_effect_index = current_entry.index_effect
 current_speed_index = current_entry.index_speed
 current_effect = current_entry.effect()

--- a/code.py
+++ b/code.py
@@ -57,9 +57,10 @@ class StateClass(object):
     def set_entry(self, entry: effects.EffectEntry):
         if entry == effects.NOT_FOUND_EFFECT or entry.full_name() == "nothing":
             self.state_on = False
+            self.entry = get_by_name("nothing")
         else:
             self.state_on = True
-        self.entry = entry
+            self.entry = entry
         self.effect_index = self.entry.index_effect
         self.speed_index = self.entry.index_speed
         self.effect = self.entry.effect()
@@ -125,7 +126,7 @@ def process_json(payload):
             if "effect" in payload:
                 the_state.set_entry(get_by_name(payload["effect"]))
             else:
-                the_state.set_entry(get_by_index(1,0))
+                the_state.set_entry(get_by_name("nothing"))
         else:
             the_state.set_entry(get_by_name("nothing"))
     pass # TODO: gc.collect() do we need this on RP2040?
@@ -182,6 +183,7 @@ next_speed = 0
 next_effect = 0
 print("before loop")
 while True:
+    mqtt_client.loop(timeout=0.1)
     the_state.effect.animate()
     if button_0.value:
         next_effect = (the_state.effect_index + 1) % EFFECTS_SIZE

--- a/code.py
+++ b/code.py
@@ -17,7 +17,8 @@ import effects
 # - indication lights/colors for wifi prob, mqtt prob, etc.
 # - offline mode
 # - home assistant autodiscovery? (make it an option in .env)
-#
+# - last on effect?
+# - support normal RGB?
 
 NUM_PIXELS = 24
 ENGINE_CORE = 12
@@ -70,6 +71,8 @@ class StateClass(object):
         else:
             self.state_on = True
             self.entry = entry
+        pixels.fill(COLOR_OFF)
+        pixels.show()
         self.effect_index = self.entry.index_effect
         self.speed_index = self.entry.index_speed
         self.effect = self.entry.effect()
@@ -135,7 +138,7 @@ def process_json(payload):
             if "effect" in payload:
                 the_state.set_entry(get_by_name(payload["effect"]))
             else:
-                the_state.set_entry(get_by_name("nothing"))
+                the_state.set_entry(get_by_index(1,0))
         else:
             the_state.set_entry(get_by_name("nothing"))
     pass # TODO: gc.collect() do we need this on RP2040?

--- a/code.py
+++ b/code.py
@@ -1,4 +1,5 @@
 import json
+import os
 import time
 
 import adafruit_minimqtt.adafruit_minimqtt as MQTT
@@ -98,7 +99,7 @@ def get_by_name(effect_name: str) -> effects.EffectEntry:
         effect_entry = EFFECTS[name][speed]
         return effect_entry
     except:
-        print("Didn't find effect %s" % name)
+        print("Didn't find effect %s" % effect_name)
         return effects.NOT_FOUND_EFFECT
 
 def get_by_index(effect: int, speed: int) -> effects.EffectEntry:
@@ -137,14 +138,12 @@ def send_state(client):
     print("Sending state %s" % state)
     client.publish(topic_state, json.dumps(state))
 
-from secrets import secrets
-
-if "name" in secrets:
-    wifi.radio.hostname = secrets["name"]
-print("Connecting to %s" % secrets["wifi"])
-wifi.radio.connect(secrets["wifi"], secrets["wifi_pw"])
-print("Connected to %s with address %s" % (secrets["wifi"], wifi.radio.ipv4_address))
-# TODO: Add logic to show errors with connections.
+if os.getenv("hostname"):
+    wifi.radio.hostname = os.getenv("hostname")
+print("Connecting to %s" % os.getenv("wifi_ssid"))
+wifi.radio.connect(os.getenv("wifi_ssid"), os.getenv("wifi_password"))
+print("Connected to %s with address %s" % (os.getenv("wifi_ssid"), wifi.radio.ipv4_address))
+# TODO: Add logic to show errors with connections *and* make it all optional
 
 
 pixels.fill((100,100,0))
@@ -160,10 +159,10 @@ print("HI")
 
 pool = socketpool.SocketPool(wifi.radio)
 mqtt_client = MQTT.MQTT(
-    broker=secrets["mqtt"],
+    broker=os.getenv("mqtt_host"),
     port=1883,
-    username=secrets["mqtt_user"],
-    password=secrets["mqtt_pw"],
+    username=os.getenv("mqtt_user"),
+    password=os.getenv("mqtt_password"),
     socket_pool=pool
 )
 

--- a/code.py
+++ b/code.py
@@ -1,8 +1,11 @@
+import json
 import time
 
+import adafruit_minimqtt.adafruit_minimqtt as MQTT
 import board
 import digitalio
 import neopixel
+import socketpool
 import wifi
 
 import effects
@@ -33,8 +36,56 @@ EFFECTS_SIZE = len(EFFECTS_ITERATIONS)
 
 print("All the supported effects: " + str([item for sublist in EFFECTS_ITERATIONS for item in sublist]))
 
+STATE_ON="ON"
+STATE_OFF="OFF"
+class StateClass(object):
+    state_on: bool = False
+    effect: effects.EffectEntry = effects.NOT_FOUND_EFFECT
+
+    def as_mqtt_state(self):
+        state = {}
+        state["state"] = STATE_ON if self.state_on else STATE_OFF
+        if self.effect and self.effect != effects.NOT_FOUND_EFFECT:
+            state["effect"] = self.effect.full_name
+        else:
+            state["effect"] = None
+        return state
+    def set_effect(self, effect: effects.EffectEntry):
+        if effect == effects.NOT_FOUND_EFFECT or effect.full_name == "nothing":
+            self.state_on = False
+        else:
+            self.state_on = True
+        self.effect = effect
+
+the_state = StateClass()
+
+topic_set = "testing/warpcore/set"
+topic_state = "testing/warpcore"
+
+def connect(mqtt_client, userdata, flags, rc):
+    print("Connected to MQTT")
+    print("Subscribing to %s" % topic_set)
+    mqtt_client.subscribe(topic_set)
+    send_state(mqtt_client)
+
+def disconnect(mqtt_client, userdata, rc):
+    print("Disconnected from MQTT")
+
+def subscribe(mqtt_client, userdata, topic, granted_qos):
+    print("Subscribed to {0} with QOS level {1}".format(topic, granted_qos))
+
+def unsubscribe(mqtt_client, userdata, topic, pid):
+    print("Unsubscribed from {0} with PID {1}".format(topic, pid))
+
+def publish(mqtt_client, userdata, topic, pid):
+    print("Published to {0}".format(topic))
+
 def get_by_name(effect_name: str) -> effects.EffectEntry:
-    name, speed = effect_name.rsplit("_", 1)
+    if "_" not in effect_name:
+        name = effect_name
+        speed = ""
+    else:
+        name, speed = effect_name.rsplit("_", 1)
     try:
         effect_entry = EFFECTS[name][speed]
         return effect_entry
@@ -48,6 +99,35 @@ def get_by_index(effect: int, speed: int) -> effects.EffectEntry:
         return effect_entry
     except:
         return effects.NOT_FOUND_EFFECT
+
+def message(client, topic, message):
+    print("New message on topic {0}: {1}".format(topic,message))
+    payload = {}
+    try:
+        payload = json.loads(message)
+    except ValueError:
+        print("Not JSON, ignore")
+        return
+    process_json(payload)
+    send_state(client)
+
+def process_json(payload):
+    global the_state
+    if "state" in payload:
+        if payload["state"] == STATE_ON:
+            if "effect" in payload:
+                the_state.set_effect(get_by_name(payload["effect"]))
+            else:
+                the_state.set_effect(get_by_index(1,0))
+        else:
+            the_state.set_effect(get_by_name("nothing"))
+    pass # gc.collect()
+    return True
+
+def send_state(client):
+    state = the_state.as_mqtt_state()
+    print("Sending state %s" % state)
+    client.publish(topic_state, json.dumps(state))
 
 from secrets import secrets
 
@@ -66,14 +146,35 @@ pixels.fill((0,0,0))
 pixels.show()
 
 # hard coding initial
-current_entry = get_by_name("nothing_")
+current_entry = get_by_name("nothing")
 current_effect_index = current_entry.index_effect
 current_speed_index = current_entry.index_speed
 current_effect = current_entry.effect()
 
 print("HI")
 
+pool = socketpool.SocketPool(wifi.radio)
+mqtt_client = MQTT.MQTT(
+    broker=secrets["mqtt"],
+    port=1883,
+    username=secrets["mqtt_user"],
+    password=secrets["mqtt_pw"],
+    socket_pool=pool
+)
+
+# Connect callback handlers to mqtt_client
+mqtt_client.on_connect = connect
+mqtt_client.on_disconnect = disconnect
+mqtt_client.on_subscribe = subscribe
+mqtt_client.on_unsubscribe = unsubscribe
+mqtt_client.on_publish = publish
+mqtt_client.on_message = message
+
+print("Attempting to connect to %s" % mqtt_client.broker)
+mqtt_client.connect()
+
 changed = False
+
 
 while True:
     current_effect.animate()

--- a/code.py
+++ b/code.py
@@ -11,6 +11,14 @@ import wifi
 
 import effects
 
+
+## TODO LIST
+# - dynamic adding of effects via .env
+# - indication lights/colors for wifi prob, mqtt prob, etc.
+# - offline mode
+# - home assistant autodiscovery? (make it an option in .env)
+#
+
 NUM_PIXELS = 24
 ENGINE_CORE = 12
 
@@ -68,8 +76,8 @@ class StateClass(object):
 
 the_state = StateClass()
 
-topic_set = "testing/warpcore/set"
-topic_state = "testing/warpcore"
+topic_set = os.getenv("mqtt_set", "testing/warpcore/set")
+topic_state = os.getenv("mqtt_state", "testing/warpcore")
 
 def connect(mqtt_client, userdata, flags, rc):
     print("Connected to MQTT")

--- a/effects.py
+++ b/effects.py
@@ -69,6 +69,7 @@ class EffectWarpEnterpriseD():
 
         # Starting conditions
         self.start_top = self.pixels.n - 1
+        # TODO: Something going on here with pixel 0 being left out
         self.start_bottom = -1 * (self.pixels.n - self.core - self.core - 1)
         self.below_steps = abs(self.start_bottom) + 3
 

--- a/effects.py
+++ b/effects.py
@@ -9,7 +9,7 @@ from adafruit_led_animation.animation.comet import Comet
 from adafruit_led_animation.animation.rainbowcomet import RainbowComet
 from neopixel import NeoPixel
 
-DEBUG = True
+DEBUG = False
 COLOR_OFF = (0,0,0)
 
 

--- a/effects.py
+++ b/effects.py
@@ -22,6 +22,8 @@ class EffectEntry(object):
         self.index_speed: int = 0
 
     def full_name(self):
+        if not self.speed:
+            return self.name
         return "%s_%s" % (self.name, self.speed)
     def __repr__(self) -> str:
         return self.full_name()


### PR DESCRIPTION
Getting the MQTT stuff working. Left a todo list in `code.py`:

## TODO LIST
* dynamic adding of effects via .env
* indication lights/colors for wifi prob, mqtt prob, etc.
* offline mode
* home assistant autodiscovery? (make it an option in .env)
* last on effect?
* support normal RGB?

Since there is no auto discovery, I added it in HA with:

```yaml
# in mqtt.yaml
light:
  - schema: json
    name: Warp Core
    state_topic: "lights/office/warpcore"
    command_topic: "lights/office/warpcore/set"
    brightness: false
    rgb: false
    effect: true
    effect_list:
      - "nothing"
      - "rainbow_0.25"
      - "rainbow_0.5"
      - "rainbow_0.1"
      - "cometbounce_purple_0.25"
      - "cometbounce_purple_0.1"
      - "warpcore_blue_0.5"
      - "warpcore_blue_0.25"
      - "warpcore_blue_0.05"
      - "warpcore_purple_0.5"
      - "warpcore_purple_0.25"
      - "warpcore_purple_0.05"
      - "warpcore_xmas_0.5"
      - "warpcore_xmas_0.25"
      - "warpcore_xmas_0.05"
    optimistic: false
    qos: 0
```